### PR TITLE
added inherited processor (with basic default behavior)

### DIFF
--- a/slice-aem60/src/main/java/com/cognifide/slice/cq/mapper/processor/InheritedFieldProcessor.java
+++ b/slice-aem60/src/main/java/com/cognifide/slice/cq/mapper/processor/InheritedFieldProcessor.java
@@ -1,0 +1,25 @@
+package com.cognifide.slice.cq.mapper.processor;
+
+import com.cognifide.slice.cq.qualifier.Inherited;
+import com.cognifide.slice.mapper.api.processor.FieldProcessor;
+import com.cognifide.slice.mapper.helper.ReflectionHelper;
+import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+
+import java.lang.reflect.Field;
+
+public class InheritedFieldProcessor implements FieldProcessor {
+
+    @Override
+    public boolean accepts(Resource resource, Field field) {
+        return field.isAnnotationPresent(Inherited.class);
+    }
+
+    @Override
+    public Object mapResourceToField(Resource resource, ValueMap valueMap,
+                                     Field field, String propertyName) {
+        Class<?> propertyType = ReflectionHelper.getFieldType(field);
+        return new HierarchyNodeInheritanceValueMap(resource).getInherited(propertyName, propertyType);
+    }
+}

--- a/slice-aem60/src/main/java/com/cognifide/slice/cq/module/CQMapperModule.java
+++ b/slice-aem60/src/main/java/com/cognifide/slice/cq/module/CQMapperModule.java
@@ -24,6 +24,7 @@ package com.cognifide.slice.cq.module;
 
 import com.cognifide.slice.api.scope.ContextScoped;
 import com.cognifide.slice.cq.mapper.processor.ImageFieldProcessor;
+import com.cognifide.slice.cq.mapper.processor.InheritedFieldProcessor;
 import com.cognifide.slice.mapper.MapperBuilder;
 import com.cognifide.slice.mapper.api.Mapper;
 import com.google.inject.AbstractModule;
@@ -44,7 +45,9 @@ public class CQMapperModule extends AbstractModule {
 	@ContextScoped
 	public Mapper getMapper(MapperBuilder mapperBuilder) {
 		ImageFieldProcessor imageProcessor = new ImageFieldProcessor();
-		return mapperBuilder.addDefaultSliceProcessors().addFieldProcessor(imageProcessor).build();
+		InheritedFieldProcessor inheritedProcessor = new InheritedFieldProcessor();
+		return mapperBuilder.addDefaultSliceProcessors().
+				addFieldProcessor(imageProcessor).addFieldProcessor(inheritedProcessor).build();
 	}
 
 }

--- a/slice-aem60/src/main/java/com/cognifide/slice/cq/qualifier/Inherited.java
+++ b/slice-aem60/src/main/java/com/cognifide/slice/cq/qualifier/Inherited.java
@@ -1,0 +1,16 @@
+package com.cognifide.slice.cq.qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Indicates that a SliceResource's field represents an inherited property, that
+ * can be obtained from one of parent resources
+ */
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface Inherited {
+}


### PR DESCRIPTION
Hi,

I added @Inherited annotation and its simple default processor which is based on AEM's HierarchyNodeInheritanceValueMap (http://docs.adobe.com/docs/en/aem/6-0/develop/ref/javadoc/com/day/cq/commons/inherit/InheritanceValueMap.html) . This implementation supports only basic JCR properties mapping, if you like it I'll provide extended version which supports inherited lists mapping, etc.

Ideally annotation @Inherited should be located inside your slice-mapper bundle, but as long as implementation is fully AEM-specific I decided to leave it here.

P.S. Recently I did a comparison of Slice versus Sling Models (based on the real code sample which I also created) - if you're interested, I can provide it to you. Slice is still the winner, however new versions of Sling Models looks very promising. ;-)

Regards,
Vladimir
